### PR TITLE
Add ProGuard rule in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,45 @@ BlipClient.openBlipThread(context, APP_KEY, blipOptions);
 
 ```
 
+## ProGuard
+
+Android apps that use [ProGuard](https://developer.android.com/studio/build/shrink-code) to obfuscate code need to add an exception in file `proguard-rules.pro` to not obfuscate the BLiP Chat code, otherwise, some BLiP Chat classes may not work properly which makes it impossible to open the chat.
+
+
+## Example
+
+```java
+-keepattributes JavascriptInterface
+-keepclassmembers class * {
+    @android.webkit.JavascriptInterface <methods>;
+}
+-keepclassmembers class net.take.blipchat.webview.WebAppInterface {
+   public *;
+}
+
+-dontwarn org.w3c.dom.bootstrap.DOMImplementationRegistry
+
+-keepclassmembers class net.take.blipchat.models.** {
+ static final long serialVersionUID;
+ private static final java.io.ObjectStreamField[] serialPersistentFields;
+ !static !transient <fields>;
+ private void writeObject(java.io.ObjectOutputStream);
+ private void readObject(java.io.ObjectInputStream);
+ java.lang.Object writeReplace();
+ java.lang.Object readResolve();
+}
+
+-keep class com.firebase.** { *; }
+-keep class org.apache.** { *; }
+-keepnames class com.fasterxml.jackson.** { *; }
+-keepnames class javax.servlet.** { *; }
+-keepnames class org.ietf.jgss.** { *; }
+-dontwarn org.apache.**
+-dontwarn org.w3c.dom.**
+-dontwarn retrofit2.**
+-keep class com.google.android.gms.internal.** { *; }
+```
+
 # Optional properties
 
 | Property          | Description                                             |


### PR DESCRIPTION
Just add the recommendation of use an specific exception on ProGuard rule for this not obfuscate some blip-chat classes.